### PR TITLE
Signatures are not required

### DIFF
--- a/otterdog/eclipse-daanse.jsonnet
+++ b/otterdog/eclipse-daanse.jsonnet
@@ -43,7 +43,6 @@ orgs.newOrg('eclipse-daanse') {
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
           required_approving_review_count: 0,
-          requires_commit_signatures: true,
           requires_linear_history: true,
           requires_strict_status_checks: true,
         },


### PR DESCRIPTION
requires_commit_signatures is not handy for some Members and also on rebaseing PRs

```
Merge attempt failed

Base branch requires signed commits. Rebase merges cannot be automatically signed by GitHub
´´´