### PR TITLE
feat: enable GitHub Pages for org.eclipse.daanse.gene

### DIFF
--- a/otterdog/eclipse-daanse.jsonnet
+++ b/otterdog/eclipse-daanse.jsonnet
@@ -113,6 +113,15 @@ orgs.newOrg('technology.daanse', 'eclipse-daanse') {
         'actions',
         'javascript-typescript',
       ],
+      gh_pages_build_type: "workflow",
+      environments: [
+        orgs.newEnvironment('github-pages') {
+          branch_policies+: [
+            "main"
+          ],
+          deployment_branch_policy: "selected",
+        },
+      ],
     },
 
     newDaanseRepo('org.eclipse.daanse.tsm') {


### PR DESCRIPTION
## Summary
- Enable GitHub Pages (workflow-based) for `org.eclipse.daanse.gene`
- Add `github-pages` environment with branch policy for `main`

Needed to deploy the GenE Release Config Page (see https://github.com/eclipse-daanse/org.eclipse.daanse.gene/pull/6).